### PR TITLE
Fix compatibility with OSX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,10 @@ if [ -f "$HOME/.vimrc" ]; then
 fi
 
 # Install
-dir="$(dirname $(readlink -f "$0"))"
+target_file="$0"
+cd `dirname $target_file`
+target_file=`basename $target_file`
+dir="$(dirname $target_file)"
 echo "Creating the .vimrc..."
 cp "${dir}/vimrc"  $HOME/.vimrc
 

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,8 @@ fi
 
 # Install
 target_file="$0"
-cd `dirname $target_file`
-target_file=`basename $target_file`
+cd $(dirname $target_file)
+target_file=$(basename $target_file)
 dir="$(dirname $target_file)"
 echo "Creating the .vimrc..."
 cp "${dir}/vimrc"  $HOME/.vimrc


### PR DESCRIPTION
`install.sh` doesn't work on OSX: it can't find the proper path of the (current directory's) vimrc.

OSX incudes BSD `readlink` instead of GNU `readlink` which does not include's `readlink -f` behavior.

This tiny patch achieves same purpose.
